### PR TITLE
7. 게시글 1개 가져오기 API 개발_모든 계층 완료

### DIFF
--- a/src/main/java/com/dss/realworld/article/api/ArticleController.java
+++ b/src/main/java/com/dss/realworld/article/api/ArticleController.java
@@ -1,13 +1,11 @@
 package com.dss.realworld.article.api;
 
-import com.dss.realworld.article.api.dto.ArticleContentDto;
+import com.dss.realworld.article.api.dto.ArticleResponseDto;
 import com.dss.realworld.article.api.dto.CreateArticleRequestDto;
-import com.dss.realworld.article.api.dto.CreateArticleResponseDto;
 import com.dss.realworld.article.app.ArticleService;
-import com.dss.realworld.article.domain.Article;
-import com.dss.realworld.common.dto.AuthorDto;
-import com.dss.realworld.error.exception.ArticleNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequestMapping(value = "/api/articles")
@@ -17,18 +15,25 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
-    @PostMapping
-    public CreateArticleResponseDto create(@RequestBody CreateArticleRequestDto createArticleRequestDto) {
-        Article article = articleService.save(createArticleRequestDto, getLogonUserId()).orElseThrow(ArticleNotFoundException::new);
-        ArticleContentDto content = ArticleContentDto.of(article.getSlug(), article.getTitle(), article.getDescription(), article.getBody(), article.getCreatedAt(), article.getUpdatedAt());
-        AuthorDto author = articleService.getAuthor(article.getUserId());
+    @GetMapping(value = "/{slug}")
+    public ResponseEntity<?> findBySlug(@PathVariable final String slug) {
+        ArticleResponseDto articleResponseDto = articleService.findBySlug(slug);
 
-        return new CreateArticleResponseDto(content, author);
+        return new ResponseEntity<>(articleResponseDto, HttpStatus.OK);
     }
 
-    @DeleteMapping(value = "{slug}")
-    public void delete(@PathVariable String slug) {
+    @PostMapping
+    public ResponseEntity<?> create(@RequestBody CreateArticleRequestDto createArticleRequestDto) {
+        ArticleResponseDto articleResponseDto = articleService.save(createArticleRequestDto, getLogonUserId());
+
+        return new ResponseEntity<>(articleResponseDto, HttpStatus.CREATED);
+    }
+
+    @DeleteMapping(value = "/{slug}")
+    public ResponseEntity<?> delete(@PathVariable String slug) {
         articleService.delete(slug, getLogonUserId());
+
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     // todo SecurityContextHolder에서 인증 정보 얻기

--- a/src/main/java/com/dss/realworld/article/api/dto/ArticleResponseDto.java
+++ b/src/main/java/com/dss/realworld/article/api/dto/ArticleResponseDto.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 @Getter
 @JsonRootName(value = "article")
-public class CreateArticleResponseDto {
+public class ArticleResponseDto {
 
     private final String slug;
     private final String title;
@@ -23,7 +23,7 @@ public class CreateArticleResponseDto {
     private final int favoritesCount = 0; // todo Following 도메인 추가 후 구현
     private final AuthorDto author;
 
-    public CreateArticleResponseDto(ArticleContentDto content, AuthorDto author) {
+    public ArticleResponseDto(ArticleContentDto content, AuthorDto author) {
         this.slug = content.getSlug();
         this.title = content.getTitle();
         this.description = content.getDescription();

--- a/src/main/java/com/dss/realworld/article/app/ArticleService.java
+++ b/src/main/java/com/dss/realworld/article/app/ArticleService.java
@@ -1,14 +1,14 @@
 package com.dss.realworld.article.app;
 
+import com.dss.realworld.article.api.dto.ArticleResponseDto;
 import com.dss.realworld.article.api.dto.CreateArticleRequestDto;
-import com.dss.realworld.article.domain.Article;
 import com.dss.realworld.common.dto.AuthorDto;
-
-import java.util.Optional;
 
 public interface ArticleService {
 
-    Optional<Article> save(CreateArticleRequestDto createArticleRequestDto, Long logonUserId);
+    ArticleResponseDto findBySlug(String slug);
+
+    ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long logonUserId);
 
     void delete(String slug, Long userId);
 

--- a/src/main/java/com/dss/realworld/article/app/ArticleService.java
+++ b/src/main/java/com/dss/realworld/article/app/ArticleService.java
@@ -8,7 +8,7 @@ public interface ArticleService {
 
     ArticleResponseDto findBySlug(String slug);
 
-    ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long logonUserId);
+    ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long loginUserId);
 
     void delete(String slug, Long userId);
 

--- a/src/main/java/com/dss/realworld/article/app/ArticleServiceImpl.java
+++ b/src/main/java/com/dss/realworld/article/app/ArticleServiceImpl.java
@@ -33,9 +33,9 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     @Transactional
-    public ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long logonUserId) {
+    public ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long loginUserId) {
         Long maxId = articleRepository.findMaxId().orElse(0L);
-        Article article = createArticleRequestDto.convert(logonUserId, maxId);
+        Article article = createArticleRequestDto.convert(loginUserId, maxId);
         articleRepository.persist(article);
 
         Article savedArticle = articleRepository.findById(article.getId()).orElseThrow(ArticleNotFoundException::new);

--- a/src/main/java/com/dss/realworld/article/app/ArticleServiceImpl.java
+++ b/src/main/java/com/dss/realworld/article/app/ArticleServiceImpl.java
@@ -34,8 +34,7 @@ public class ArticleServiceImpl implements ArticleService {
     @Override
     @Transactional
     public ArticleResponseDto save(CreateArticleRequestDto createArticleRequestDto, Long logonUserId) {
-        Long maxId = articleRepository.findMaxId();
-        if (maxId == null) maxId = 0L;
+        Long maxId = articleRepository.findMaxId().orElse(0L);
         Article article = createArticleRequestDto.convert(logonUserId, maxId);
         articleRepository.persist(article);
 

--- a/src/main/java/com/dss/realworld/article/domain/repository/ArticleRepository.java
+++ b/src/main/java/com/dss/realworld/article/domain/repository/ArticleRepository.java
@@ -16,7 +16,7 @@ public interface ArticleRepository {
 
     int delete(Long id);
 
-    Long findMaxId();
+    Optional<Long> findMaxId();
 
     Optional<Article> findById(Long id);
 

--- a/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
+++ b/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
@@ -48,6 +48,7 @@ public class ArticleControllerTest {
     @BeforeEach
     void setUp() {
         clearTable();
+        userRepository.persist(UserFixtures.create());
     }
 
     @AfterEach
@@ -134,7 +135,7 @@ public class ArticleControllerTest {
     }
 
     private Long getSampleUserId() {
-        User user = UserFixtures.create();
+        User user = UserFixtures.create("kate","katepwd","kate@kate.kate");
         userRepository.persist(user);
 
         return user.getId();

--- a/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
+++ b/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
@@ -1,11 +1,10 @@
 package com.dss.realworld.article.api;
 
+import com.dss.realworld.article.api.dto.ArticleResponseDto;
 import com.dss.realworld.article.api.dto.CreateArticleRequestDto;
 import com.dss.realworld.article.app.ArticleService;
-import com.dss.realworld.article.domain.Article;
 import com.dss.realworld.article.domain.Slug;
 import com.dss.realworld.article.domain.repository.ArticleRepository;
-import com.dss.realworld.error.exception.ArticleNotFoundException;
 import com.dss.realworld.user.domain.User;
 import com.dss.realworld.user.domain.repository.UserRepository;
 import com.dss.realworld.util.ArticleFixtures;
@@ -73,11 +72,11 @@ public class ArticleControllerTest {
         //given
         Long logonId = 1L;
         CreateArticleRequestDto articleDto = createArticleDto();
-        Article savedArticle = articleService.save(articleDto, logonId).orElseThrow(ArticleNotFoundException::new);
-        assertThat(savedArticle.getUserId()).isEqualTo(logonId);
+        ArticleResponseDto articleResponseDto = articleService.save(articleDto, logonId);
+        assertThat(articleResponseDto.getTitle()).isEqualTo(articleDto.getTitle());
 
         //when
-        String slug = savedArticle.getSlug();
+        String slug = articleResponseDto.getSlug();
         MockHttpServletRequestBuilder mockRequest = MockMvcRequestBuilders
                 .delete("/api/articles/" + slug)
                 .contentType(MediaType.TEXT_PLAIN);
@@ -109,7 +108,7 @@ public class ArticleControllerTest {
 
         //then
         mockMvc.perform(mockRequest)
-                .andExpect(status().isOk())
+                .andExpect(status().isCreated())
                 .andExpect(jsonPath("$..title").value(title))
                 .andExpect(jsonPath("$..slug").value(Slug.of(title,0L).getValue()))
                 .andExpect(jsonPath("$..favorited").value(false))

--- a/src/test/java/com/dss/realworld/article/app/ArticleServiceTest.java
+++ b/src/test/java/com/dss/realworld/article/app/ArticleServiceTest.java
@@ -1,10 +1,14 @@
 package com.dss.realworld.article.app;
 
+import com.dss.realworld.article.api.dto.ArticleResponseDto;
 import com.dss.realworld.article.api.dto.CreateArticleRequestDto;
 import com.dss.realworld.article.domain.Article;
 import com.dss.realworld.article.domain.repository.ArticleRepository;
 import com.dss.realworld.error.exception.ArticleNotFoundException;
+import com.dss.realworld.user.domain.User;
+import com.dss.realworld.user.domain.repository.UserRepository;
 import com.dss.realworld.util.ArticleFixtures;
+import com.dss.realworld.util.UserFixtures;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +25,9 @@ public class ArticleServiceTest {
 
     @Autowired
     private ArticleRepository articleRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Autowired
     private ArticleService articleService;
@@ -79,14 +86,17 @@ public class ArticleServiceTest {
     @Test
     void t3() {
         //given
-        Long logonId = 1L;
+        User user = UserFixtures.create();
+        userRepository.persist(user);
+        Long loginId = user.getId();
+
         CreateArticleRequestDto createArticleRequestDto = createArticleDto();
 
         //when
-        Article savedArticle = articleService.save(createArticleRequestDto, logonId).orElseThrow(ArticleNotFoundException::new);
+        ArticleResponseDto articleResponseDto = articleService.save(createArticleRequestDto, loginId);
 
         //then
-        assertThat(savedArticle.getUserId()).isEqualTo(logonId);
+        assertThat(articleResponseDto.getTitle()).isEqualTo(createArticleRequestDto.getTitle());
     }
 
     private CreateArticleRequestDto createArticleDto() {

--- a/src/test/java/com/dss/realworld/article/app/ArticleServiceTest.java
+++ b/src/test/java/com/dss/realworld/article/app/ArticleServiceTest.java
@@ -43,6 +43,9 @@ public class ArticleServiceTest {
     }
 
     private void clearTable() {
+        userRepository.deleteAll();
+        userRepository.resetAutoIncrement();
+
         articleRepository.deleteAll();
         articleRepository.resetAutoIncrement();
     }
@@ -101,7 +104,7 @@ public class ArticleServiceTest {
     }
 
     private Article saveArticle(Long userId) {
-        Article newArticle = ArticleFixtures.create(userId);
+        Article newArticle = ArticleFixtures.of(userId);
         articleRepository.persist(newArticle);
 
         return newArticle;

--- a/src/test/java/com/dss/realworld/article/domain/repository/ArticleRepositoryTest.java
+++ b/src/test/java/com/dss/realworld/article/domain/repository/ArticleRepositoryTest.java
@@ -64,7 +64,7 @@ public class ArticleRepositoryTest {
         String title = "How to train your dragon";
         String slug = "How-to-train-your-dragon-1";
 
-        Article newArticle = ArticleFixtures.create(title, slug);
+        Article newArticle = ArticleFixtures.of(title, slug);
         articleRepository.persist(newArticle);
 
         Optional<Article> foundArticle = articleRepository.findBySlug(newArticle.getSlug());

--- a/src/test/java/com/dss/realworld/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/dss/realworld/comment/api/CommentControllerTest.java
@@ -50,7 +50,7 @@ class CommentControllerTest {
         User newUser = UserFixtures.create();
         userRepository.persist(newUser);
 
-        Article newArticle = ArticleFixtures.create(newUser.getId());
+        Article newArticle = ArticleFixtures.of(newUser.getId());
         articleRepository.persist(newArticle);
     }
 

--- a/src/test/java/com/dss/realworld/comment/app/CommentServiceTest.java
+++ b/src/test/java/com/dss/realworld/comment/app/CommentServiceTest.java
@@ -39,7 +39,7 @@ class CommentServiceTest {
         User newUser = UserFixtures.create();
         userRepository.persist(newUser);
 
-        Article newArticle = ArticleFixtures.create(newUser.getId());
+        Article newArticle = ArticleFixtures.of(newUser.getId());
         articleRepository.persist(newArticle);
     }
 

--- a/src/test/java/com/dss/realworld/comment/domain/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/dss/realworld/comment/domain/repository/CommentRepositoryTest.java
@@ -39,7 +39,7 @@ class CommentRepositoryTest {
         User newUser = UserFixtures.create();
         userRepository.persist(newUser);
 
-        Article newArticle = ArticleFixtures.create(newUser.getId());
+        Article newArticle = ArticleFixtures.of(newUser.getId());
         articleRepository.persist(newArticle);
     }
 

--- a/src/test/java/com/dss/realworld/util/ArticleFixtures.java
+++ b/src/test/java/com/dss/realworld/util/ArticleFixtures.java
@@ -13,7 +13,7 @@ public class ArticleFixtures {
                 .build();
     }
 
-    public static Article create(Long userId) {
+    public static Article of(Long userId) {
         return Article.builder()
                 .title("How to train your dragon")
                 .slug("How-to-train-your-dragon-1")
@@ -23,7 +23,17 @@ public class ArticleFixtures {
                 .build();
     }
 
-    public static Article create(String title, String slug) {
+    public static Article of(String slug, Long userId) {
+        return Article.builder()
+                .title("How to train your dragon")
+                .slug(slug)
+                .description("Ever wonder how?")
+                .body("You have to believe")
+                .userId(userId)
+                .build();
+    }
+
+    public static Article of(String title, String slug) {
         return Article.builder()
                 .title(title)
                 .slug(slug)


### PR DESCRIPTION
게시글 생성 시 게시글을 반환하는 로직이 이전 개발 때 완료되어
게시글 1건 조회에 대한 repository 테스트는 생략했습니다.

그리고 앞으로 서비스 계층에서 DTO를 반환하고 컨트롤러 계층에서는
반환된 DTO를 ResponseEntity<>()에 담는 로직으로 전부 수정하는 게 좋겠습니다.

Comment 도메인 개발 시에 참고 바랍니다.