### PR TITLE
refactor-01-Article 응답, 요청 객체 JSON 반환 방법 변경

### DIFF
--- a/src/main/java/com/dss/realworld/article/api/ArticleController.java
+++ b/src/main/java/com/dss/realworld/article/api/ArticleController.java
@@ -17,28 +17,28 @@ public class ArticleController {
     private final ArticleService articleService;
 
     @GetMapping(value = "/{slug}")
-    public ResponseEntity<?> findBySlug(@PathVariable final String slug) {
+    public ResponseEntity<ArticleResponseDto> findBySlug(@PathVariable final String slug) {
         ArticleResponseDto articleResponseDto = articleService.findBySlug(slug);
 
         return new ResponseEntity<>(articleResponseDto, HttpStatus.OK);
     }
 
     @PostMapping
-    public ResponseEntity<?> create(@RequestBody final CreateArticleRequestDto createArticleRequestDto) {
+    public ResponseEntity<ArticleResponseDto> create(@RequestBody final CreateArticleRequestDto createArticleRequestDto) {
         ArticleResponseDto articleResponseDto = articleService.save(createArticleRequestDto, getLoginUserId());
 
         return new ResponseEntity<>(articleResponseDto, HttpStatus.CREATED);
     }
 
     @PutMapping(value = "/{slug}")
-    public ResponseEntity<?> update(@RequestBody final UpdateArticleRequestDto updateArticleRequestDto, @PathVariable final String slug) {
+    public ResponseEntity<ArticleResponseDto> update(@RequestBody final UpdateArticleRequestDto updateArticleRequestDto, @PathVariable final String slug) {
         ArticleResponseDto articleResponseDto = articleService.update(updateArticleRequestDto, getLoginUserId(), slug);
 
         return new ResponseEntity<>(articleResponseDto, HttpStatus.CREATED);
     }
 
     @DeleteMapping(value = "/{slug}")
-    public ResponseEntity<?> delete(@PathVariable final String slug) {
+    public ResponseEntity<ArticleResponseDto> delete(@PathVariable final String slug) {
         articleService.delete(slug, getLoginUserId());
 
         return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/dss/realworld/article/api/dto/ArticleResponseDto.java
+++ b/src/main/java/com/dss/realworld/article/api/dto/ArticleResponseDto.java
@@ -1,7 +1,10 @@
 package com.dss.realworld.article.api.dto;
 
 import com.dss.realworld.common.dto.AuthorDto;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -9,14 +12,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Getter
-@JsonRootName(value = "article")
+@JsonTypeName(value = "article")
+@JsonTypeInfo(include = As.WRAPPER_OBJECT, use = Id.NAME)
 public class ArticleResponseDto {
 
     private final String slug;
     private final String title;
     private final String description;
     private final String body;
-    private final Set<String> tagList = new HashSet<>(); // todo Tag 도메인 추가 후 구현
+    private final Set<String> tagList = new HashSet<>();
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
     private final boolean favorited = false; // todo Following 도메인 추가 후 구현

--- a/src/main/java/com/dss/realworld/article/api/dto/CreateArticleRequestDto.java
+++ b/src/main/java/com/dss/realworld/article/api/dto/CreateArticleRequestDto.java
@@ -2,7 +2,12 @@ package com.dss.realworld.article.api.dto;
 
 import com.dss.realworld.article.domain.Article;
 import com.dss.realworld.article.domain.Slug;
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.dss.realworld.tag.domain.Tag;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,21 +15,28 @@ import lombok.NoArgsConstructor;
 import java.util.Set;
 
 @Getter
-@JsonRootName(value = "article")
+@JsonTypeName(value = "article")
+@JsonTypeInfo(include = As.WRAPPER_OBJECT, use = Id.NAME)
 @NoArgsConstructor
 public class CreateArticleRequestDto {
 
+    @NotNull
     private String title;
+
+    @NotNull
     private String description;
+
+    @NotNull
     private String body;
-    private Set<String> tagList;
+
+    private Set<Tag> tags;
 
     @Builder
-    public CreateArticleRequestDto(final String title, final String description, final String body, final Set<String> tagList) {
+    public CreateArticleRequestDto(final String title, final String description, final String body, final Set<Tag> tags) {
         this.title = title;
         this.description = description;
         this.body = body;
-        this.tagList = tagList;
+        this.tags = tags;
     }
 
     public Article convert(Long logonUserId, Long maxArticleId) {

--- a/src/main/java/com/dss/realworld/article/api/dto/UpdateArticleRequestDto.java
+++ b/src/main/java/com/dss/realworld/article/api/dto/UpdateArticleRequestDto.java
@@ -1,12 +1,16 @@
 package com.dss.realworld.article.api.dto;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@JsonRootName(value = "article")
+@JsonTypeName(value = "article")
+@JsonTypeInfo(include = As.WRAPPER_OBJECT, use = Id.NAME)
 @NoArgsConstructor
 public class UpdateArticleRequestDto {
 

--- a/src/main/java/com/dss/realworld/config/AppConfig.java
+++ b/src/main/java/com/dss/realworld/config/AppConfig.java
@@ -1,6 +1,5 @@
 package com.dss.realworld.config;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
@@ -14,8 +13,6 @@ public class AppConfig {
     public Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder() {
         return new Jackson2ObjectMapperBuilder()
                 .modules(new JavaTimeModule())
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-//                .featuresToEnable(SerializationFeature.WRAP_ROOT_VALUE)
-                .featuresToEnable(DeserializationFeature.UNWRAP_ROOT_VALUE);
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     }
 }

--- a/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
+++ b/src/test/java/com/dss/realworld/article/api/ArticleControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -59,7 +60,6 @@ public class ArticleControllerTest {
         String body = "You have to believe";
         CreateArticleRequestDto newArticle = ArticleFixtures.createRequestDto(title, description, body);
 
-        //when
         String jsonString = objectMapper.writeValueAsString(newArticle);
         MockHttpServletRequestBuilder mockRequest = MockMvcRequestBuilders
                 .post("/api/articles")
@@ -67,17 +67,22 @@ public class ArticleControllerTest {
                 .accept(MediaType.APPLICATION_JSON)
                 .content(jsonString);
 
+        //when
+        ResultActions resultActions = mockMvc.perform(mockRequest);
+        String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
         //then
-        mockMvc.perform(mockRequest)
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$..title").value(title))
-                .andExpect(jsonPath("$..slug").value(Slug.of(title, 0L, true).getValue()))
-                .andExpect(jsonPath("$..favorited").value(false))
-                .andExpect(jsonPath("$..following").value(false))
-                .andExpect(jsonPath("$..username").value("Jacob000"))
-                .andExpect(jsonPath("$..description").value(description))
-                .andExpect(jsonPath("$..body").value(body))
-                .andExpect(jsonPath("$..tagList.length()").value(0));
+        resultActions
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$..title").value(title))
+            .andExpect(jsonPath("$..slug").value(Slug.of(title, 0L, true).getValue()))
+            .andExpect(jsonPath("$..favorited").value(false))
+            .andExpect(jsonPath("$..following").value(false))
+            .andExpect(jsonPath("$..username").value("Jacob000"))
+            .andExpect(jsonPath("$..description").value(description))
+            .andExpect(jsonPath("$..body").value(body))
+            .andExpect(jsonPath("$..tagList.length()").value(0));
     }
 
     @DisplayName(value = "slug, userId가 유효하면 Article 삭제 성공")


### PR DESCRIPTION
@JsonRootName 대신 @JsonTypeName, @JsonTypeInfo, 일급 컬렉션을 사용하여 JSON 객체를 반환하도록 변경했습니다.

단일 객체 반환 시 이너 클래스를 만들지 않아도 되고
List 반환 시에만 일급 컬렉션을 사용하도록 하여
코드 작성을 최소화했습니다.